### PR TITLE
Use transitive dependencies from spring boot and spring cloud, Update the Spring Cloud and Spring Boot versions to 2022.0.4 and 3.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This project has dependency and transitive dependencies on Spring Projects. The 
 
 | Spring Cloud OCI  | Spring Cloud              | Spring Boot         | OCI Java SDK |
 |-------------------|---------------------------|---------------------|--------------|
-| 1.0.0  	        | 2021.0.x                  | 2.7.x               |  3.19.0      |
+| 1.0.0  	        | 2022.0.x                  | 3.1.x, 3.0.x        |  3.19.0      |
 
 
 ## Try out samples

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 
     <properties>
         <spring-cloud-oci-dependencies.version>${project.version}</spring-cloud-oci-dependencies.version>
-        <spring-cloud-dependencies.version>2021.0.2</spring-cloud-dependencies.version>
-        <spring-boot-dependencies.version>2.7.4</spring-boot-dependencies.version>
+        <spring-cloud-dependencies.version>2022.0.4</spring-cloud-dependencies.version>
+        <spring-boot-dependencies.version>3.1.2</spring-boot-dependencies.version>
         <oci-sdk.version>3.19.0</oci-sdk.version>
         <spring-boot-maven-plugin.version>3.1.2</spring-boot-maven-plugin.version>
         <maven.compiler.source>17</maven.compiler.source>
@@ -71,7 +71,6 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
         <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
         <springdoc-openapi-ui.version>1.6.13</springdoc-openapi-ui.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
-        <jackson-core.version>2.13.1</jackson-core.version>
         <lombok.version>1.18.20</lombok.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <slf4j-simple.version>1.7.33</slf4j-simple.version>
@@ -102,11 +101,6 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>${jackson-core.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.projectlombok</groupId>

--- a/spring-cloud-oci-core/pom.xml
+++ b/spring-cloud-oci-core/pom.xml
@@ -46,12 +46,8 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
     </properties>
     <dependencies>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
         </dependency>
         <dependency>
             <groupId>com.oracle.oci.sdk</groupId>

--- a/spring-cloud-oci-logging/pom.xml
+++ b/spring-cloud-oci-logging/pom.xml
@@ -46,14 +46,6 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 	</properties>
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>com.oracle.cloud.spring</groupId>
 			<artifactId>spring-cloud-oci-core</artifactId>
 		</dependency>

--- a/spring-cloud-oci-notification/pom.xml
+++ b/spring-cloud-oci-notification/pom.xml
@@ -46,14 +46,6 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 	</properties>
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>com.oracle.cloud.spring</groupId>
 			<artifactId>spring-cloud-oci-core</artifactId>
 		</dependency>

--- a/spring-cloud-oci-storage/pom.xml
+++ b/spring-cloud-oci-storage/pom.xml
@@ -48,14 +48,6 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 
     <dependencies>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.oracle.cloud.spring</groupId>
             <artifactId>spring-cloud-oci-core</artifactId>
         </dependency>


### PR DESCRIPTION
Use transitive dependencies from spring boot and spring cloud, Update the Spring Cloud and Spring Boot versions to 2022.0.4 and 3.1.2